### PR TITLE
Support `go get` commands to install from Github repo

### DIFF
--- a/src/background/advisory/openbase.js
+++ b/src/background/advisory/openbase.js
@@ -69,6 +69,7 @@ const getOpenbasePackage = (packageName, packageLang) =>
 const typeMap = {
   npm: 'JS',
   pypi: 'PYTHON',
+  go: 'GO',
 };
 
 export default async ({ type, name }) => {

--- a/src/background/advisory/snyk.js
+++ b/src/background/advisory/snyk.js
@@ -65,6 +65,7 @@ const scrapeScoreFromSnyk = (registry, packageName) =>
 const typesMap = {
   npm: 'npm-package',
   pypi: 'python',
+  go: 'golang',
 };
 
 export default async ({ type, name }) => {

--- a/src/content/registry/go.js
+++ b/src/content/registry/go.js
@@ -1,0 +1,4 @@
+export const parseCommand = (command = '') => {
+  console.log('go.js:parseCommand', command);
+  return [];
+};

--- a/src/content/registry/go.js
+++ b/src/content/registry/go.js
@@ -29,7 +29,7 @@ export const parseCommand = (command = '') => {
         continue;
       }
 
-      const packageMatch = word.match(/^(?<name>github\.com(\/\w[\w.]+){2})(\/[\w.]+)*(@[\w.]+)?$/);
+      const packageMatch = word.match(/^(?<name>github\.com(\/\w[\w.-]+){2})(\/[\w.-]+)*(@[\w.-]+)?$/);
       if (!packageMatch) {
         counterIndex += word.length + 1;
         continue;

--- a/src/content/registry/go.js
+++ b/src/content/registry/go.js
@@ -36,6 +36,7 @@ export const parseCommand = (command = '') => {
       }
 
       packages.push({
+        type: 'go',
         name: packageMatch.groups.name,
         startIndex: counterIndex,
         endIndex: counterIndex + packageMatch[0].length,

--- a/src/content/registry/go.js
+++ b/src/content/registry/go.js
@@ -29,7 +29,7 @@ export const parseCommand = (command = '') => {
         continue;
       }
 
-      const packageMatch = word.match(/^(?<name>\w[\w./]+)(@[\w.]+)?$/);
+      const packageMatch = word.match(/^(?<name>github\.com(\/\w[\w.]+){2})(\/[\w.]+)*(@[\w.]+)?$/);
       if (!packageMatch) {
         counterIndex += word.length + 1;
         continue;

--- a/src/content/registry/go.js
+++ b/src/content/registry/go.js
@@ -1,4 +1,49 @@
 export const parseCommand = (command = '') => {
-  console.log('go.js:parseCommand', command);
-  return [];
+  const packages = [];
+  let counterIndex = 0;
+
+  const lines = command.split('\n');
+  while (lines.length > 0) {
+    const line = lines.shift();
+
+    const goGetMatch = line.match(/go +(get|install)/);
+    if (!goGetMatch) {
+      counterIndex += line.length + 1; // +1 for the newline
+      continue;
+    }
+
+    const goGetLength = goGetMatch.index + goGetMatch[0].length;
+    counterIndex += goGetLength;
+    const argsAndPackagesWords = line.slice(goGetLength).split(' ');
+
+    while (argsAndPackagesWords.length > 0) {
+      const word = argsAndPackagesWords.shift();
+
+      if (!word) {
+        counterIndex++;
+        continue;
+      }
+
+      if (word.startsWith('-')) {
+        counterIndex += word.length + 1;
+        continue;
+      }
+
+      const packageMatch = word.match(/^(?<name>\w[\w./]+)(@[\w.]+)?$/);
+      if (!packageMatch) {
+        counterIndex += word.length + 1;
+        continue;
+      }
+
+      packages.push({
+        name: packageMatch.groups.name,
+        startIndex: counterIndex,
+        endIndex: counterIndex + packageMatch[0].length,
+      });
+
+      counterIndex += word.length + 1;
+    }
+  }
+
+  return packages;
 };

--- a/src/content/registry/go.test.js
+++ b/src/content/registry/go.test.js
@@ -7,12 +7,19 @@ const positionInCommand = (command, packageName, endIndex) => {
 };
 
 describe(parseCommand.name, () => {
-  it.each([undefined, '', 'just a text', 'go get', 'go get -u', 'go get -u -v', 'go get https://github.com/user/package'])(
-    `should not find a package in '%s'`,
-    (text) => {
-      expect(parseCommand(text)).toStrictEqual([]);
-    }
-  );
+  it.each([
+    undefined,
+    '',
+    'just a text',
+    'go get',
+    'go get -u',
+    'go get -u -v',
+    'go get https://github.com/user/package',
+    'go get code.google.com/p/goauth2/oauth',
+    'go get golang.org/x/tools/cmd/godoc',
+  ])(`should not find a package in '%s'`, (text) => {
+    expect(parseCommand(text)).toStrictEqual([]);
+  });
 
   it.each(['github.com/user/package'])(`should find the package %s`, (packageName) => {
     const command = `go get ${packageName}`;
@@ -41,16 +48,14 @@ describe(parseCommand.name, () => {
 
   it('should find package with github subfolder', () => {
     const command = 'go get -u github.com/golang/lint/golint';
-    const expectedPackages = [positionInCommand(command, 'github.com/golang/lint/golint')];
-
-    const packagePosition = parseCommand(command);
-
-    expect(packagePosition).toStrictEqual(expectedPackages);
-  });
-
-  it('should find package from code.google.com', () => {
-    const command = 'go get code.google.com/p/goauth2/oauth';
-    const expectedPackages = [positionInCommand(command, 'code.google.com/p/goauth2/oauth')];
+    const expectedPackages = [
+      {
+        type: 'go',
+        name: 'github.com/golang/lint',
+        startIndex: 10,
+        endIndex: 10 + 'github.com/golang/lint/golint'.length,
+      },
+    ];
 
     const packagePosition = parseCommand(command);
 

--- a/src/content/registry/go.test.js
+++ b/src/content/registry/go.test.js
@@ -1,0 +1,73 @@
+import { describe, expect, it } from '@jest/globals';
+import { parseCommand } from './go';
+
+const positionInCommand = (command, packageName) => {
+  const startIndex = command.indexOf(packageName);
+  return { name: packageName, startIndex, endIndex: startIndex + packageName.length };
+};
+
+describe(parseCommand.name, () => {
+  it.each([
+    undefined,
+    '',
+    'just a text',
+    'go get',
+    'go get -u',
+    'go get -u -v',
+    'go get https://github.com/user/package',
+    'go get code.google.com/p/goauth2/oauth',
+  ])(`should not find a package in '%s'`, (text) => {
+    expect(parseCommand(text)).toStrictEqual([]);
+  });
+
+  it.each(['github.com/user/package'])(`should find the package %s`, (packageName) => {
+    const command = `go get ${packageName}`;
+    const expectedPackages = [positionInCommand(command, packageName)];
+
+    const packagePosition = parseCommand(command);
+
+    expect(packagePosition).toStrictEqual(expectedPackages);
+  });
+
+  it.each([
+    ['go get', 'go get github.com/user/package'],
+    ['with flag', 'go get -u github.com/user/package'],
+    ['go install', 'go install github.com/user/package'],
+    ['with branch', 'go get github.com/user/package@master'],
+    ['with version', 'go get github.com/user/package@v1.12.0'],
+    ['with commit hash', 'go get github.com/user/package@b2bd9c3'],
+  ])(`should find the package in command with '%s'`, (_, command) => {
+    const expectedPackages = [positionInCommand(command, 'github.com/user/package')];
+
+    const packagePosition = parseCommand(command);
+
+    expect(packagePosition).toStrictEqual(expectedPackages);
+  });
+
+  it('should find multiple packages', () => {
+    const command = 'go get github.com/google/uuid github.com/nu7hatch/gouuid';
+    const expectedPackages = [
+      positionInCommand(command, 'github.com/google/uuid'),
+      positionInCommand(command, 'github.com/nu7hatch/gouuid'),
+    ];
+
+    const packagePosition = parseCommand(command);
+
+    expect(packagePosition).toStrictEqual(expectedPackages);
+  });
+
+  it('should find in multiline', () => {
+    const command = `
+      go get github.com/google/uuid
+      go get github.com/nu7hatch/gouuid
+    `;
+    const expectedPackages = [
+      positionInCommand(command, 'github.com/google/uuid'),
+      positionInCommand(command, 'github.com/nu7hatch/gouuid'),
+    ];
+
+    const packagePosition = parseCommand(command);
+
+    expect(packagePosition).toStrictEqual(expectedPackages);
+  });
+});

--- a/src/content/registry/go.test.js
+++ b/src/content/registry/go.test.js
@@ -1,24 +1,18 @@
 import { describe, expect, it } from '@jest/globals';
 import { parseCommand } from './go';
 
-const positionInCommand = (command, packageName) => {
+const positionInCommand = (command, packageName, endIndex) => {
   const startIndex = command.indexOf(packageName);
-  return { name: packageName, startIndex, endIndex: startIndex + packageName.length };
+  return { name: packageName, startIndex, endIndex: endIndex || startIndex + packageName.length };
 };
 
 describe(parseCommand.name, () => {
-  it.each([
-    undefined,
-    '',
-    'just a text',
-    'go get',
-    'go get -u',
-    'go get -u -v',
-    'go get https://github.com/user/package',
-    'go get code.google.com/p/goauth2/oauth',
-  ])(`should not find a package in '%s'`, (text) => {
-    expect(parseCommand(text)).toStrictEqual([]);
-  });
+  it.each([undefined, '', 'just a text', 'go get', 'go get -u', 'go get -u -v', 'go get https://github.com/user/package'])(
+    `should not find a package in '%s'`,
+    (text) => {
+      expect(parseCommand(text)).toStrictEqual([]);
+    }
+  );
 
   it.each(['github.com/user/package'])(`should find the package %s`, (packageName) => {
     const command = `go get ${packageName}`;
@@ -37,7 +31,16 @@ describe(parseCommand.name, () => {
     ['with version', 'go get github.com/user/package@v1.12.0'],
     ['with commit hash', 'go get github.com/user/package@b2bd9c3'],
   ])(`should find the package in command with '%s'`, (_, command) => {
-    const expectedPackages = [positionInCommand(command, 'github.com/user/package')];
+    const expectedPackages = [positionInCommand(command, 'github.com/user/package', command.length)];
+
+    const packagePosition = parseCommand(command);
+
+    expect(packagePosition).toStrictEqual(expectedPackages);
+  });
+
+  it('should find package from code.google.com', () => {
+    const command = 'go get code.google.com/p/goauth2/oauth';
+    const expectedPackages = [positionInCommand(command, 'code.google.com/p/goauth2/oauth')];
 
     const packagePosition = parseCommand(command);
 

--- a/src/content/registry/go.test.js
+++ b/src/content/registry/go.test.js
@@ -62,6 +62,15 @@ describe(parseCommand.name, () => {
     expect(packagePosition).toStrictEqual(expectedPackages);
   });
 
+  it('should support special characters', () => {
+    const command = 'go get github.com/U-ser1/p.A-ck_age2';
+    const expectedPackages = [positionInCommand(command, 'github.com/U-ser1/p.A-ck_age2')];
+
+    const packagePosition = parseCommand(command);
+
+    expect(packagePosition).toStrictEqual(expectedPackages);
+  });
+
   it('should find multiple packages', () => {
     const command = 'go get github.com/google/uuid github.com/nu7hatch/gouuid';
     const expectedPackages = [

--- a/src/content/registry/go.test.js
+++ b/src/content/registry/go.test.js
@@ -3,7 +3,7 @@ import { parseCommand } from './go';
 
 const positionInCommand = (command, packageName, endIndex) => {
   const startIndex = command.indexOf(packageName);
-  return { name: packageName, startIndex, endIndex: endIndex || startIndex + packageName.length };
+  return { type: 'go', name: packageName, startIndex, endIndex: endIndex || startIndex + packageName.length };
 };
 
 describe(parseCommand.name, () => {
@@ -30,8 +30,18 @@ describe(parseCommand.name, () => {
     ['with branch', 'go get github.com/user/package@master'],
     ['with version', 'go get github.com/user/package@v1.12.0'],
     ['with commit hash', 'go get github.com/user/package@b2bd9c3'],
+    ['with patch', 'go get -u=patch github.com/user/package'],
   ])(`should find the package in command with '%s'`, (_, command) => {
     const expectedPackages = [positionInCommand(command, 'github.com/user/package', command.length)];
+
+    const packagePosition = parseCommand(command);
+
+    expect(packagePosition).toStrictEqual(expectedPackages);
+  });
+
+  it('should find package with github subfolder', () => {
+    const command = 'go get -u github.com/golang/lint/golint';
+    const expectedPackages = [positionInCommand(command, 'github.com/golang/lint/golint')];
 
     const packagePosition = parseCommand(command);
 

--- a/src/content/registry/python.js
+++ b/src/content/registry/python.js
@@ -61,7 +61,7 @@ const pipOptionsWithArgToIgnore = [
   '--cache-dir',
 ];
 
-const packageArea = /(?<=\s|^)["']?(?<package_part>(?<package_name>\w[\w.-]*)([=<>~!]=?[\w.,<>]+)?)["']?(?=\s|$)/;
+const packageArea = /^["']?(?<package_part>(?<package_name>\w[\w.-]*)([=<>~!]=?[\w.,<>]+)?)["']?$/;
 
 const handleArgument = (argument, restCommandWords) => {
   let index = 0;

--- a/src/content/stackoverflow/finder.js
+++ b/src/content/stackoverflow/finder.js
@@ -1,3 +1,4 @@
+import * as go from '../registry/go';
 import * as npm from '../registry/npm';
 import * as python from '../registry/python';
 import { getRangeOfPositions } from './range';
@@ -19,7 +20,7 @@ const urlParsers = {
   ...python.urlParsers,
 };
 
-const codeBlockParsers = [npm.parseCommand, python.parseCommand];
+const codeBlockParsers = [npm.parseCommand, python.parseCommand, go.parseCommand];
 
 export const findRanges = (body) => {
   const links = Array.from(body.querySelectorAll(`${POST_SELECTOR} a`))

--- a/tests/real-examples/real-examples-results.yaml
+++ b/tests/real-examples/real-examples-results.yaml
@@ -1247,3 +1247,39 @@ https://stackoverflow.com/questions/5226504:
     - range: <code>pip install -I package==2.0.0</code>
       type: pypi
       name: package
+https://stackoverflow.com/a/27709931:
+  comment: go get standard library
+  post: answer
+  registry: go
+  results: []
+https://stackoverflow.com/a/47433983:
+  comment: link to github and command
+  post: answer
+  registry: go
+  results: []
+https://stackoverflow.com/a/29242504:
+  comment: go install
+  post: answer
+  registry: go
+  results: []
+https://stackoverflow.com/a/16901657:
+  comment: not existing package
+  post: answer
+  registry: go
+  results: []
+https://stackoverflow.com/a/15374626:
+  comment: package from code.google.com
+  post: answer
+  registry: go
+  results: []
+https://stackoverflow.com/a/57694628:
+  comment: go get with version
+  post: answer
+  registry: go
+  results:
+    - range: |-
+        <code>$ npm install express@4.0.0
+        </code>
+      type: npm
+      name: express
+      version: 4.0.0

--- a/tests/real-examples/real-examples-results.yaml
+++ b/tests/real-examples/real-examples-results.yaml
@@ -1251,27 +1251,204 @@ https://stackoverflow.com/a/27709931:
   comment: go get standard library
   post: answer
   registry: go
-  results: []
+  results:
+    - range: |-
+        <code>go get golang.org/x/tools/cmd/godoc
+        </code>
+      type: go
+      name: golang.org/x/tools/cmd/godoc
+    - range: >-
+        <code>$ brew install go
+
+        ==&gt; Downloading
+        https://homebrew.bintray.com/bottles/go-1.7.1.sierra.bottle.tar.gz
+
+        Already downloaded:
+        /Users/nigel/Library/Caches/Homebrew/go-1.7.1.sierra.bottle.tar.gz
+
+        ==&gt; Pouring go-1.7.1.sierra.bottle.tar.gz
+
+        ==&gt; Caveats
+
+        As of go 1.2, a valid GOPATH is required to use the `go get` command:
+          https://golang.org/doc/code.html#GOPATH
+
+        You may wish to add the GOROOT-based install location to your PATH:
+          export PATH=$PATH:/usr/local/opt/go/libexec/bin
+        ==&gt; Summary
+
+        🍺  /usr/local/Cellar/go/1.7.1: 6,436 files, 250.6M
+
+
+        $ go get golang.org/x/tools/cmd/godoc
+
+
+        $ go get github.com/golang/lint/golint
+
+
+        $ go get golang.org/x/tour/gotour
+
+
+        $ gotour
+
+        2016/10/19 12:06:54 Serving content from
+        /Users/nigel/.go/src/golang.org/x/tour
+
+        2016/10/19 12:06:54 A browser window should open. If not, please visit
+        http://127.0.0.1:3999
+
+        2016/10/19 12:06:55 accepting connection from: 127.0.0.1:52958
+
+        </code>
+      type: go
+      name: golang.org/x/tools/cmd/godoc
+    - range: >-
+        <code>$ brew install go
+
+        ==&gt; Downloading
+        https://homebrew.bintray.com/bottles/go-1.7.1.sierra.bottle.tar.gz
+
+        Already downloaded:
+        /Users/nigel/Library/Caches/Homebrew/go-1.7.1.sierra.bottle.tar.gz
+
+        ==&gt; Pouring go-1.7.1.sierra.bottle.tar.gz
+
+        ==&gt; Caveats
+
+        As of go 1.2, a valid GOPATH is required to use the `go get` command:
+          https://golang.org/doc/code.html#GOPATH
+
+        You may wish to add the GOROOT-based install location to your PATH:
+          export PATH=$PATH:/usr/local/opt/go/libexec/bin
+        ==&gt; Summary
+
+        🍺  /usr/local/Cellar/go/1.7.1: 6,436 files, 250.6M
+
+
+        $ go get golang.org/x/tools/cmd/godoc
+
+
+        $ go get github.com/golang/lint/golint
+
+
+        $ go get golang.org/x/tour/gotour
+
+
+        $ gotour
+
+        2016/10/19 12:06:54 Serving content from
+        /Users/nigel/.go/src/golang.org/x/tour
+
+        2016/10/19 12:06:54 A browser window should open. If not, please visit
+        http://127.0.0.1:3999
+
+        2016/10/19 12:06:55 accepting connection from: 127.0.0.1:52958
+
+        </code>
+      type: go
+      name: github.com/golang/lint/golint
+    - range: >-
+        <code>$ brew install go
+
+        ==&gt; Downloading
+        https://homebrew.bintray.com/bottles/go-1.7.1.sierra.bottle.tar.gz
+
+        Already downloaded:
+        /Users/nigel/Library/Caches/Homebrew/go-1.7.1.sierra.bottle.tar.gz
+
+        ==&gt; Pouring go-1.7.1.sierra.bottle.tar.gz
+
+        ==&gt; Caveats
+
+        As of go 1.2, a valid GOPATH is required to use the `go get` command:
+          https://golang.org/doc/code.html#GOPATH
+
+        You may wish to add the GOROOT-based install location to your PATH:
+          export PATH=$PATH:/usr/local/opt/go/libexec/bin
+        ==&gt; Summary
+
+        🍺  /usr/local/Cellar/go/1.7.1: 6,436 files, 250.6M
+
+
+        $ go get golang.org/x/tools/cmd/godoc
+
+
+        $ go get github.com/golang/lint/golint
+
+
+        $ go get golang.org/x/tour/gotour
+
+
+        $ gotour
+
+        2016/10/19 12:06:54 Serving content from
+        /Users/nigel/.go/src/golang.org/x/tour
+
+        2016/10/19 12:06:54 A browser window should open. If not, please visit
+        http://127.0.0.1:3999
+
+        2016/10/19 12:06:55 accepting connection from: 127.0.0.1:52958
+
+        </code>
+      type: go
+      name: golang.org/x/tour/gotour
 https://stackoverflow.com/a/47433983:
   comment: link to github and command
   post: answer
   registry: go
-  results: []
+  results:
+    - range: |-
+        <code>go get github.com/nu7hatch/gouuid
+        </code>
+      type: go
+      name: github.com/nu7hatch/gouuid
+    - range: |-
+        <code>go get github.com/twinj/uuid
+        </code>
+      type: go
+      name: github.com/twinj/uuid
 https://stackoverflow.com/a/29242504:
   comment: go install
   post: answer
   registry: go
-  results: []
+  results:
+    - range: |-
+        <code>ifdef GODEBUG  
+            GOPATH="${PWD}" go install github.com/mailgun/godebug
+            GOPATH="${PWD}" ./bin/godebug build -instrument "${GODEBUG}" -o bin/rrdns rrdns
+        </code>
+      type: go
+      name: github.com/mailgun/godebug
 https://stackoverflow.com/a/16901657:
   comment: not existing package
   post: answer
   registry: go
-  results: []
+  results:
+    - range: |-
+        <code>$ go get github.com/username/newmath
+        </code>
+      type: go
+      name: github.com/username/newmath
+    - range: |-
+        <code>$ go get github.com/username/hello
+        $ go install github.com/username/hello
+        </code>
+      type: go
+      name: github.com/username/hello
+    - range: |-
+        <code>$ go get github.com/username/hello
+        $ go install github.com/username/hello
+        </code>
+      type: go
+      name: github.com/username/hello
 https://stackoverflow.com/a/15374626:
   comment: package from code.google.com
   post: answer
   registry: go
-  results: []
+  results:
+    - range: <code>go get code.google.com/p/goauth2/oauth</code>
+      type: go
+      name: code.google.com/p/goauth2/oauth
 https://stackoverflow.com/a/57694628:
   comment: go get with version
   post: answer
@@ -1283,3 +1460,84 @@ https://stackoverflow.com/a/57694628:
       type: npm
       name: express
       version: 4.0.0
+    - range: |-
+        <code>$ go get github.com/wilk/uuid@0.0.1
+        $ go get github.com/wilk/uuid@0.0.2
+        </code>
+      type: go
+      name: github.com/wilk/uuid
+    - range: |-
+        <code>$ go get github.com/wilk/uuid@0.0.1
+        $ go get github.com/wilk/uuid@0.0.2
+        </code>
+      type: go
+      name: github.com/wilk/uuid
+    - range: <code>go get github.com/gorilla/mux@v1.7.4</code>
+      type: go
+      name: github.com/gorilla/mux
+    - range: |-
+        <code>export GOPATH=~/
+        go get github.com/whateveruser/whateverrepo
+        cd ~/src/github.com/whateveruser/whateverrepo
+        git tag -l
+        # supose tag v0.0.2 is correct version
+        git checkout tags/v0.0.2
+        go run whateverpackage/main.go
+        </code>
+      type: go
+      name: github.com/whateveruser/whateverrepo
+    - range: |-
+        <code>go get github.com/someone/some_module@master
+        go get github.com/someone/some_module@v1.1.0
+        go get github.com/someone/some_module@commit_hash
+        </code>
+      type: go
+      name: github.com/someone/some_module
+    - range: |-
+        <code>go get github.com/someone/some_module@master
+        go get github.com/someone/some_module@v1.1.0
+        go get github.com/someone/some_module@commit_hash
+        </code>
+      type: go
+      name: github.com/someone/some_module
+    - range: |-
+        <code>go get github.com/someone/some_module@master
+        go get github.com/someone/some_module@v1.1.0
+        go get github.com/someone/some_module@commit_hash
+        </code>
+      type: go
+      name: github.com/someone/some_module
+    - range: |-
+        <code>go install github.com/someone/some_module
+        </code>
+      type: go
+      name: github.com/someone/some_module
+    - range: |-
+        <code>go install github.com/someone/some_module@v1.1.0
+        </code>
+      type: go
+      name: github.com/someone/some_module
+    - range: |-
+        <code>go install github.com/someone/some_module@commit_hash
+        </code>
+      type: go
+      name: github.com/someone/some_module
+https://stackoverflow.com/a/28857808:
+  comment: github subfolder
+  post: answer
+  registry: go
+  results:
+    - range: >-
+        <code>$ sudo go get -u github.com/golang/lint/golint
+
+        package github.com/golang/lint/golint: cannot download, $GOPATH not set.
+        For more details see: go help gopath
+
+        </code>
+      type: go
+      name: github.com/golang/lint/golint
+    - range: |-
+        <code>go get -u github.com/golang/lint/golint
+        </code>
+      type: go
+      name: github.com/golang/lint/golint

--- a/tests/real-examples/real-examples-results.yaml
+++ b/tests/real-examples/real-examples-results.yaml
@@ -1352,7 +1352,7 @@ https://stackoverflow.com/a/15374626:
   registry: go
   results: []
 https://stackoverflow.com/a/57694628:
-  comment: go get with version
+  comment: go get with version and special chars
   post: answer
   registry: go
   results:
@@ -1409,6 +1409,16 @@ https://stackoverflow.com/a/57694628:
         </code>
       type: go
       name: github.com/someone/some_module
+    - range: >-
+        <code>GO111MODULE=on go get -u
+        github.com/segmentio/aws-okta@v0.22.1</code>
+      type: go
+      name: github.com/segmentio/aws-okta
+    - range: |-
+        <code>go get github.com/go-gl/mathgl@v1.0.0
+        </code>
+      type: go
+      name: github.com/go-gl/mathgl
     - range: |-
         <code>go install github.com/someone/some_module
         </code>

--- a/tests/real-examples/real-examples-results.yaml
+++ b/tests/real-examples/real-examples-results.yaml
@@ -1252,11 +1252,6 @@ https://stackoverflow.com/a/27709931:
   post: answer
   registry: go
   results:
-    - range: |-
-        <code>go get golang.org/x/tools/cmd/godoc
-        </code>
-      type: go
-      name: golang.org/x/tools/cmd/godoc
     - range: >-
         <code>$ brew install go
 
@@ -1301,97 +1296,7 @@ https://stackoverflow.com/a/27709931:
 
         </code>
       type: go
-      name: golang.org/x/tools/cmd/godoc
-    - range: >-
-        <code>$ brew install go
-
-        ==&gt; Downloading
-        https://homebrew.bintray.com/bottles/go-1.7.1.sierra.bottle.tar.gz
-
-        Already downloaded:
-        /Users/nigel/Library/Caches/Homebrew/go-1.7.1.sierra.bottle.tar.gz
-
-        ==&gt; Pouring go-1.7.1.sierra.bottle.tar.gz
-
-        ==&gt; Caveats
-
-        As of go 1.2, a valid GOPATH is required to use the `go get` command:
-          https://golang.org/doc/code.html#GOPATH
-
-        You may wish to add the GOROOT-based install location to your PATH:
-          export PATH=$PATH:/usr/local/opt/go/libexec/bin
-        ==&gt; Summary
-
-        🍺  /usr/local/Cellar/go/1.7.1: 6,436 files, 250.6M
-
-
-        $ go get golang.org/x/tools/cmd/godoc
-
-
-        $ go get github.com/golang/lint/golint
-
-
-        $ go get golang.org/x/tour/gotour
-
-
-        $ gotour
-
-        2016/10/19 12:06:54 Serving content from
-        /Users/nigel/.go/src/golang.org/x/tour
-
-        2016/10/19 12:06:54 A browser window should open. If not, please visit
-        http://127.0.0.1:3999
-
-        2016/10/19 12:06:55 accepting connection from: 127.0.0.1:52958
-
-        </code>
-      type: go
-      name: github.com/golang/lint/golint
-    - range: >-
-        <code>$ brew install go
-
-        ==&gt; Downloading
-        https://homebrew.bintray.com/bottles/go-1.7.1.sierra.bottle.tar.gz
-
-        Already downloaded:
-        /Users/nigel/Library/Caches/Homebrew/go-1.7.1.sierra.bottle.tar.gz
-
-        ==&gt; Pouring go-1.7.1.sierra.bottle.tar.gz
-
-        ==&gt; Caveats
-
-        As of go 1.2, a valid GOPATH is required to use the `go get` command:
-          https://golang.org/doc/code.html#GOPATH
-
-        You may wish to add the GOROOT-based install location to your PATH:
-          export PATH=$PATH:/usr/local/opt/go/libexec/bin
-        ==&gt; Summary
-
-        🍺  /usr/local/Cellar/go/1.7.1: 6,436 files, 250.6M
-
-
-        $ go get golang.org/x/tools/cmd/godoc
-
-
-        $ go get github.com/golang/lint/golint
-
-
-        $ go get golang.org/x/tour/gotour
-
-
-        $ gotour
-
-        2016/10/19 12:06:54 Serving content from
-        /Users/nigel/.go/src/golang.org/x/tour
-
-        2016/10/19 12:06:54 A browser window should open. If not, please visit
-        http://127.0.0.1:3999
-
-        2016/10/19 12:06:55 accepting connection from: 127.0.0.1:52958
-
-        </code>
-      type: go
-      name: golang.org/x/tour/gotour
+      name: github.com/golang/lint
 https://stackoverflow.com/a/47433983:
   comment: link to github and command
   post: answer
@@ -1445,10 +1350,7 @@ https://stackoverflow.com/a/15374626:
   comment: package from code.google.com
   post: answer
   registry: go
-  results:
-    - range: <code>go get code.google.com/p/goauth2/oauth</code>
-      type: go
-      name: code.google.com/p/goauth2/oauth
+  results: []
 https://stackoverflow.com/a/57694628:
   comment: go get with version
   post: answer
@@ -1535,9 +1437,9 @@ https://stackoverflow.com/a/28857808:
 
         </code>
       type: go
-      name: github.com/golang/lint/golint
+      name: github.com/golang/lint
     - range: |-
         <code>go get -u github.com/golang/lint/golint
         </code>
       type: go
-      name: github.com/golang/lint/golint
+      name: github.com/golang/lint

--- a/tests/real-examples/real-examples.yaml
+++ b/tests/real-examples/real-examples.yaml
@@ -106,3 +106,7 @@ links:
     comment: go get with version
     post: answer
     registry: go
+  https://stackoverflow.com/a/28857808:
+    comment: github subfolder
+    post: answer
+    registry: go

--- a/tests/real-examples/real-examples.yaml
+++ b/tests/real-examples/real-examples.yaml
@@ -81,3 +81,28 @@ links:
     comment: flags, quotes and version variants
     post: answer
     registry: pypi
+
+  https://stackoverflow.com/a/27709931:
+    comment: go get standard library
+    post: answer
+    registry: go
+  https://stackoverflow.com/a/47433983:
+    comment: link to github and command
+    post: answer
+    registry: go
+  https://stackoverflow.com/a/29242504:
+    comment: go install
+    post: answer
+    registry: go
+  https://stackoverflow.com/a/16901657:
+    comment: not existing package
+    post: answer
+    registry: go
+  https://stackoverflow.com/a/15374626:
+    comment: package from code.google.com
+    post: answer
+    registry: go
+  https://stackoverflow.com/a/57694628:
+    comment: go get with version
+    post: answer
+    registry: go

--- a/tests/real-examples/real-examples.yaml
+++ b/tests/real-examples/real-examples.yaml
@@ -103,7 +103,7 @@ links:
     post: answer
     registry: go
   https://stackoverflow.com/a/57694628:
-    comment: go get with version
+    comment: go get with version and special chars
     post: answer
     registry: go
   https://stackoverflow.com/a/28857808:


### PR DESCRIPTION
- add real examples for go
- TDD
- Support `go get` commands to install from Github repo Fixes #46

#### Limitations
- Links are not supported (see #45)
- Only installs from `github.com` are supported. Listed in #45.