### PR TITLE
refactor: build advisory related strings with the advisories data

### DIFF
--- a/src/background/advisory/debricked.js
+++ b/src/background/advisory/debricked.js
@@ -61,12 +61,16 @@ export default async ({ type, name }) => {
   const { metrics: packageMetrics } = await getOshData(dependencyId);
 
   let issues = 0;
+  let summaries = [];
 
   const badges = Object.values(packageMetrics).reduce((acc, { score, metric_type_id }) => {
     const { name, description } = model[metric_type_id];
     const roundedScore = Math.round(score / 10);
+    summaries.push(`${name}: ${roundedScore}/100`);
+
     const level = getLevel(roundedScore);
     if (level === 'BAD') issues++;
+
     acc[name] = {
       description,
       score: roundedScore,
@@ -77,6 +81,8 @@ export default async ({ type, name }) => {
 
   return {
     issues,
+    summary: summaries.join(', '),
+    reportUrl: `https://debricked.com/select/package/${type}-${name}`,
     data: badges,
   };
 };

--- a/src/background/advisory/debricked.js
+++ b/src/background/advisory/debricked.js
@@ -61,7 +61,7 @@ export default async ({ type, name }) => {
   const { metrics: packageMetrics } = await getOshData(dependencyId);
 
   let issues = 0;
-  let summaries = [];
+  const summaries = [];
 
   const badges = Object.values(packageMetrics).reduce((acc, { score, metric_type_id }) => {
     const { name, description } = model[metric_type_id];

--- a/src/background/advisory/debricked.test.js
+++ b/src/background/advisory/debricked.test.js
@@ -7,6 +7,8 @@ describe('debricked', () => {
 
     expect(res).toStrictEqual({
       issues: expect.any(Number),
+      reportUrl: expect.any(String),
+      summary: expect.any(String),
       data: {
         Contributors: {
           description: expect.any(String),

--- a/src/background/advisory/deps-dev.js
+++ b/src/background/advisory/deps-dev.js
@@ -57,6 +57,8 @@ export default async ({ type, name }) => {
 
   return {
     issues: 0,
+    summary: `Score: ${project?.scorecardV2.score}/10`,
+    reportUrl: `https://deps.dev/${type}/${name}`,
     data: {
       latestVersion: version,
       repo: links.repo,

--- a/src/background/advisory/deps-dev.test.js
+++ b/src/background/advisory/deps-dev.test.js
@@ -7,6 +7,8 @@ describe('deps-dev', () => {
 
     expect(res).toStrictEqual({
       issues: expect.any(Number),
+      reportUrl: expect.any(String),
+      summary: expect.any(String),
       data: {
         latestVersion: '18.2.0',
         repo: 'https://github.com/facebook/react',

--- a/src/background/advisory/snyk.js
+++ b/src/background/advisory/snyk.js
@@ -37,6 +37,7 @@ const scrapeScoreFromSnyk = (registry, packageName) =>
     const level = barLevelToLevel[$(SNYK_SCORE_BAR_SELECTOR).attr()['data-level']];
 
     let issues = 0;
+
     const badges = $(SNYK_SECURITY_SCORE_SELECTOR)
       .toArray()
       .reduce((acc, li) => {
@@ -51,8 +52,12 @@ const scrapeScoreFromSnyk = (registry, packageName) =>
         return acc;
       }, {});
 
+    const descriptions = Object.values(badges).map(({ description }) => description);
+
     return {
       issues,
+      summary: `Score: ${score}/${maxScore}, ${descriptions.join(', ')}`,
+      reportUrl: `https://snyk.io/advisor/${registry}/${packageName}`,
       data: {
         score,
         maxScore,

--- a/src/background/advisory/snyk.test.js
+++ b/src/background/advisory/snyk.test.js
@@ -7,6 +7,8 @@ describe('snyk', () => {
 
     expect(res).toStrictEqual({
       issues: expect.any(Number),
+      reportUrl: expect.any(String),
+      summary: expect.any(String),
       data: {
         score: expect.any(Number),
         maxScore: 100,

--- a/src/background/advisory/socket.js
+++ b/src/background/advisory/socket.js
@@ -37,10 +37,14 @@ export default async ({ type, name }) => {
   const { score: scoresList } = await getPackageDetails(typesMap[type], name);
 
   let issues = 0;
+  const summaries = [];
+
   const scores = Object.entries(scoresList)
     .filter(([scoreName, { score }]) => scoreName !== 'miscellaneous' && typeof score === 'number')
     .reduce((acc, [scoreName, { score }]) => {
       const roundedScore = Math.ceil(score * 100);
+      summaries.push(`${scoreName}: ${roundedScore}/100`);
+
       const level = getLevel(roundedScore);
       if (level === 'BAD') issues++;
 
@@ -50,6 +54,8 @@ export default async ({ type, name }) => {
 
   return {
     issues,
+    summary: summaries.join(', '),
+    reportUrl: `https://socket.dev/${type}/package/${name}`,
     data: scores,
   };
 };

--- a/src/background/advisory/socket.test.js
+++ b/src/background/advisory/socket.test.js
@@ -11,6 +11,8 @@ describe('socket', () => {
     });
     expect(res).toStrictEqual({
       issues: expect.any(Number),
+      reportUrl: expect.any(String),
+      summary: expect.any(String),
       data: {
         license: expectScore,
         maintenance: expectScore,

--- a/src/custom-elements/Indicator.vue
+++ b/src/custom-elements/Indicator.vue
@@ -128,44 +128,9 @@ export default defineComponent({
   },
   computed: {
     sources() {
-      let sources = [];
+      if (!this.packageInfo?.sources) return [];
 
-      // TODO filter displayed sources based on the user settings
-      for (const [sourceId, source] of Object.entries(this.packageInfo?.sources || {})) {
-        let summary = 'No information';
-        let reportUrl = '';
-
-        console.log(sourceId, source);
-        if (sourceId === 'depsDev') {
-          summary = `Score: ${source.data.scorecard.score}/10`;
-          reportUrl = `https://deps.dev/${this.packageType}/${this.packageName}`;
-        } else if (sourceId === 'socket') {
-          summary = `Supply Chain Risk: ${source.data.supplyChainRisk.score}/100, Vulnerability: ${source.data.vulnerability.score}/100, Quality: ${source.data.quality.score}/100, Maintenance: ${source.data.maintenance.score}/100`;
-          reportUrl = `https://socket.dev/${this.packageType}/package/${this.packageName}`;
-        } else if (sourceId === 'snyk') {
-          summary = `Score: ${source.data.score}/100, ${source.data.badges.security.description}, ${source.data.badges.community.description}, ${source.data.badges.maintenance.description}, ${source.data.badges.popularity.description}`;
-
-          let snykAdvisorPackageType = '';
-          if (this.packageType === 'npm') {
-            snykAdvisorPackageType = 'npm-package';
-          } else if (this.packageType === 'pypi') {
-            snykAdvisorPackageType = 'python';
-          }
-          reportUrl = `https://snyk.io/advisor/${snykAdvisorPackageType}/${this.packageName}`;
-        } else if (sourceId === 'debricked') {
-          summary = `Security: ${source.data.Security.score}/100, Contributors: ${source.data.Contributors.score}/100, Popularity:${source.data.Popularity.score}/100`;
-          reportUrl = `https://debricked.com/select/package/${this.packageType}-${this.packageName}`;
-        }
-
-        sources.push({
-          id: sourceId,
-          summary: summary,
-          reportUrl: reportUrl,
-          ...source,
-        });
-      }
-
-      return sources;
+      return Object.entries(this.packageInfo.sources).map(([sourceId, source]) => ({ ...source, id: sourceId }));
     },
     packageLicense() {
       return this.packageInfo?.licenses[0] || '';


### PR DESCRIPTION
I prefer building the advisory-related strings like `summary` and `reportUrl` with the `data` itself, because those strings are related to the advisory, and to its internal data structure, and generating them in another place require us to identify the advisory again, and jump between the advisory and our code to understand the data structure.
