### PR TITLE
fix: ignore pypi /packages/source/v/ url

### DIFF
--- a/src/content/registry/python.js
+++ b/src/content/registry/python.js
@@ -1,6 +1,8 @@
 import { createParseCommand } from './shared';
 
 const registryParser = ({ pathname }) => {
+  if (pathname.includes('/packages/source/v/')) return;
+
   const [_empty, _part, name, version] = pathname.split('/');
   return {
     type: 'pypi',

--- a/src/content/stackoverflow/finder.test.js
+++ b/src/content/stackoverflow/finder.test.js
@@ -51,10 +51,7 @@ describe(findRanges.name, () => {
     it.each(['http://npmjs.org/', 'https://pypi.python.org/packages/source/v/virtualenv/virtualenv-12.0.7.tar.gz'])(
       `Should not find any package in '%s'`,
       (url) => {
-        const body = document.createElement('body');
-        const a1 = document.createElement('a');
-        a1.href = url;
-        body.appendChild(a1);
+        const { body } = createRealAnswer(`<a id="test" href="${url}">test</a>`);
 
         const foundElements = findRanges(body);
 


### PR DESCRIPTION
Should ignore (or support in another way) links of type: https://pypi.python.org/packages/source/v/virtualenv/virtualenv-12.0.7.tar.gz

(cherry picked from commit 9d035c0cc7ba539d5c86d59e962dc50c4888a95a)
