### PR TITLE
fix: Link of a scoped package not opened correctly (issue #97)

### DIFF
--- a/src/background/advisory/deps-dev.js
+++ b/src/background/advisory/deps-dev.js
@@ -58,7 +58,7 @@ export default async ({ type, name }) => {
   return {
     issues: 0,
     summary: `Score: ${project?.scorecardV2.score}/10`,
-    reportUrl: `https://deps.dev/${type}/${name}`,
+    reportUrl: `https://deps.dev/${type}/${encodeURIComponent(name)}`,
     data: {
       latestVersion: version,
       repo: links.repo,


### PR DESCRIPTION
encoded the package name to ensure the link will open properly.

Close #97 