### PR TITLE
fix: pluralize issues number

### DIFF
--- a/src/custom-elements/PackageReport.vue
+++ b/src/custom-elements/PackageReport.vue
@@ -37,7 +37,9 @@
         </div>
 
         <div class="overlay-indicator__tooltip__source__issues" v-if="source.issues">
-          <div class="overlay-indicator__tooltip__source__issues__wrapper">{{ source.issues }} issue</div>
+          <div class="overlay-indicator__tooltip__source__issues__wrapper">
+            {{ source.issues }} issue{{ source.issues !== 1 ? 's' : '' }}
+          </div>
         </div>
 
         <div class="overlay-indicator__tooltip__source__actions">


### PR DESCRIPTION
Displays '2 issues' rather than '2 issue' if multiple issues have been found by an advisory source. 

Pluralize tested against: 
https://www.npmjs.com/package/react-scripts
https://pypi.org/project/openpyxl-templates/

Checking for regression issues against the following, which should show singular issues in one of the artifacts.
https://www.npmjs.com/package/react-day-picker
https://www.npmjs.com/package/node-sass
https://pypi.org/project/pydub/

Lint output:
```
xxxxxxxxxxxxxx:~/Projects/overlay$ npm run lint

> lint
> eslint src tests e2e
```

yarn test output:
```
Test Suites: 12 passed, 12 total
Tests:       1 skipped, 193 passed, 194 total
Snapshots:   0 total
Time:        5.022 s
Ran all test suites.
Done in 5.98s.
```