### PR TITLE
Ignore commands with ".whl" in handleArgument function

### DIFF
--- a/src/content/registry/python.js
+++ b/src/content/registry/python.js
@@ -77,6 +77,11 @@ const handleArgument = (argument, restCommandWords) => {
     }
     return index;
   }
+  
+  if (argument.includes('.whl')) {
+    console.log('Ignoring command with ".whl":', argument);
+    return -1; // Return a negative index to indicate the command should be ignored
+  }
 
   if (!pipOptionsWithArgToIgnore.includes(argument)) {
     return index;

--- a/tests/real-examples/real-examples.yaml
+++ b/tests/real-examples/real-examples.yaml
@@ -97,7 +97,6 @@ links:
     comment: pip3 install command
     post: answer
     registry: pypi
-
   https://stackoverflow.com/a/27709931:
     comment: go get standard library
     post: answer
@@ -124,5 +123,9 @@ links:
     registry: go
   https://stackoverflow.com/a/28857808:
     comment: github subfolder
+    post: answer
+    registry: go
+  https://stackoverflow.com/a/33984261:
+    comment: wsl should not running 
     post: answer
     registry: go


### PR DESCRIPTION
In the handleArgument function, added a check to ignore commands that include the ".whl" string. This prevents such commands from being processed further.

When encountering a command with ".whl", a log message is printed indicating that the command is being ignored. The function returns a negative index (-1) to signify the command should be ignored.

This change improves the handling of commands and ensures that any commands containing ".whl" are excluded from further processing.

Close #119 