### PR TITLE
fix: ignore pip install .whl file

### DIFF
--- a/src/content/registry/python.js
+++ b/src/content/registry/python.js
@@ -90,6 +90,11 @@ const handleArgument = (argument, restCommandWords) => {
 
 const baseCommandMatch = (line) => line.match(/pip3? +install/);
 const packageWordParse = (word) => {
+  if (word.endsWith('.whl')) {
+    console.debug('Ignoring package with ".whl":', word);
+    return null;
+  }
+
   const match = word.match(packageArea);
   if (!match) return null;
 

--- a/src/content/registry/python.test.js
+++ b/src/content/registry/python.test.js
@@ -17,6 +17,7 @@ describe(parseCommand.name, () => {
     'install numpy‑1.9.2+mkl‑cp34‑none‑win_amd64.whl',
     'install MySQL_python==', // Although this is a valid package name, it's not a valid command
     'install -r requirements.txt',
+    'pip install scipy-0.16.1-cp27-none-win_amd64.whl',
   ];
   const createCommand = (packageManager) => commands.map((command) => `${packageManager} ${command}`);
 

--- a/src/content/registry/python.test.js
+++ b/src/content/registry/python.test.js
@@ -17,7 +17,7 @@ describe(parseCommand.name, () => {
     'install numpy‑1.9.2+mkl‑cp34‑none‑win_amd64.whl',
     'install MySQL_python==', // Although this is a valid package name, it's not a valid command
     'install -r requirements.txt',
-    'pip install scipy-0.16.1-cp27-none-win_amd64.whl',
+    'install scipy-0.16.1-cp27-none-win_amd64.whl',
   ];
   const createCommand = (packageManager) => commands.map((command) => `${packageManager} ${command}`);
 

--- a/tests/real-examples/real-examples-results.yaml
+++ b/tests/real-examples/real-examples-results.yaml
@@ -1984,10 +1984,111 @@ https://stackoverflow.com/questions/26575587:
       type: pypi
       name: pip
     - range: |-
-        <code>pip install scipy-0.16.1-cp27-none-win_amd64.whl
+        <code>$ sudo apt-get install libatlas-base-dev gfortran
+        $ sudo pip3 install scipy
         </code>
       type: pypi
-      name: scipy-0.16.1-cp27-none-win_amd64.whl
+      name: scipy
+    - range: <code>pip install scipy</code>
+      type: pypi
+      name: scipy
+    - range: |-
+        <code>brew install gcc 
+        pip install scipy
+        </code>
+      type: pypi
+      name: scipy
+    - range: |-
+        <code>pip install scipy
+        </code>
+      type: pypi
+      name: scipy
+    - range: |-
+        <code>$ sudo pip install scipy
+        </code>
+      type: pypi
+      name: scipy
+    - range: >-
+        <code>python -m pip install --user numpy scipy matplotlib ipython
+        jupyter pandas sympy nose
+
+        </code>
+      type: pypi
+      name: numpy
+    - range: >-
+        <code>python -m pip install --user numpy scipy matplotlib ipython
+        jupyter pandas sympy nose
+
+        </code>
+      type: pypi
+      name: scipy
+    - range: >-
+        <code>python -m pip install --user numpy scipy matplotlib ipython
+        jupyter pandas sympy nose
+
+        </code>
+      type: pypi
+      name: matplotlib
+    - range: >-
+        <code>python -m pip install --user numpy scipy matplotlib ipython
+        jupyter pandas sympy nose
+
+        </code>
+      type: pypi
+      name: ipython
+    - range: >-
+        <code>python -m pip install --user numpy scipy matplotlib ipython
+        jupyter pandas sympy nose
+
+        </code>
+      type: pypi
+      name: jupyter
+    - range: >-
+        <code>python -m pip install --user numpy scipy matplotlib ipython
+        jupyter pandas sympy nose
+
+        </code>
+      type: pypi
+      name: pandas
+    - range: >-
+        <code>python -m pip install --user numpy scipy matplotlib ipython
+        jupyter pandas sympy nose
+
+        </code>
+      type: pypi
+      name: sympy
+    - range: >-
+        <code>python -m pip install --user numpy scipy matplotlib ipython
+        jupyter pandas sympy nose
+
+        </code>
+      type: pypi
+      name: nose
+https://stackoverflow.com/a/33984261:
+  comment: should Ignore this .whl as a package
+  post: answer
+  registry: pypi
+  results:
+    - range: >-
+        <a href="https://pypi.python.org/pypi/scipy" rel="nofollow
+        noreferrer">https://pypi.python.org/pypi/scipy</a>
+      type: pypi
+      name: scipy
+    - range: |-
+        <code>pip install scipy
+        </code>
+      type: pypi
+      name: scipy
+    - range: |-
+        <code>pip install --upgrade pip
+        </code>
+      type: pypi
+      name: pip
+    - range: |-
+        <code>python3 -m pip install --upgrade pip
+        </code>
+      type: pypi
+      name: pip
     - range: |-
         <code>$ sudo apt-get install libatlas-base-dev gfortran
         $ sudo pip3 install scipy
@@ -2009,28 +2110,10 @@ https://stackoverflow.com/questions/26575587:
       type: pypi
       name: scipy
     - range: |-
-        <code>pip install FileName.whl
-        </code>
-      type: pypi
-      name: FileName.whl
-    - range: <code>pip install scipy-0.15.1-cp33-none-win_amd64.whl.whl</code>
-      type: pypi
-      name: scipy-0.15.1-cp33-none-win_amd64.whl.whl
-    - range: |-
         <code>$ sudo pip install scipy
         </code>
       type: pypi
       name: scipy
-    - range: |-
-        <code>
-            @echo off
-            C:\Python36\python.exe -m pip -V
-            C:\Python36\python.exe -m pip install scipy-0.19.1-cp36-cp36m-win32.whl
-            C:\Python36\python.exe -m pip list
-            pause
-        </code>
-      type: pypi
-      name: scipy-0.19.1-cp36-cp36m-win32.whl
     - range: >-
         <code>python -m pip install --user numpy scipy matplotlib ipython
         jupyter pandas sympy nose

--- a/tests/real-examples/real-examples.yaml
+++ b/tests/real-examples/real-examples.yaml
@@ -97,6 +97,10 @@ links:
     comment: pip3 install command
     post: answer
     registry: pypi
+  https://stackoverflow.com/a/33984261:
+    comment: should Ignore this .whl as a package
+    post: answer
+    registry: pypi
 
   https://stackoverflow.com/a/27709931:
     comment: go get standard library
@@ -126,7 +130,3 @@ links:
     comment: github subfolder
     post: answer
     registry: go
-  https://stackoverflow.com/a/33984261:
-    comment: should Ignore this .whl as a package
-    post: answer
-    registry: pypi

--- a/tests/real-examples/real-examples.yaml
+++ b/tests/real-examples/real-examples.yaml
@@ -126,3 +126,7 @@ links:
     comment: github subfolder
     post: answer
     registry: go
+  https://stackoverflow.com/a/33984261:
+    comment: should Ignore this .whl as a package
+    post: answer
+    registry: pypi


### PR DESCRIPTION
Continue of #140 
Close #119 

I added a change for ignore commands that end with `.whl`,
and I also added an example to real-examples.yaml 