### PR TITLE
fix: overlay breaks the ui on npmjs.com (#158)

### DIFF
--- a/src/content/content.npmjs.js
+++ b/src/content/content.npmjs.js
@@ -19,7 +19,7 @@ const addPackageReport = async (packageID) => {
   packageReport.setAttribute('package-name', packageID.name);
 
   const properties = collaborators.parentElement.parentElement;
-  const install = properties.querySelector('p');
+  const install = properties.querySelector('div.d767adf4.lh-copy');
   install.after(packageReport);
 };
 


### PR DESCRIPTION
Fix #158

change the injected overlay to be after the div element that represent the "nom install <package>
after the fix here is the screenshots:

**npmjs.com**
![Screen Shot 2024-02-15 at 13 12 27](https://github.com/os-scar/overlay/assets/6542413/ca069e2b-9c57-4183-ac6a-9ba2092e5754)

**pypi.org**
![Screen Shot 2024-02-15 at 13 12 41](https://github.com/os-scar/overlay/assets/6542413/282df1c3-5841-4cd0-ab4f-c9bee0477702)

**stackoverflow.com**
![Screen Shot 2024-02-15 at 13 13 13](https://github.com/os-scar/overlay/assets/6542413/eb4c384a-5097-417f-ad4a-d575990e6fb3)
