### PR TITLE
test: run e2e nightly tests and open issue on failure

### DIFF
--- a/.github/ISSUE_TEMPLATE/playwright-nightly-failed.md
+++ b/.github/ISSUE_TEMPLATE/playwright-nightly-failed.md
@@ -1,0 +1,9 @@
+---
+title: Playwright Nightly failed
+assignees: baruchiro
+labels: bug
+---
+
+The tests against the real npm, pypi and Go websites failed.
+
+Check it [here](https://github.com/os-scar/overlay/actions/workflows/playwright.yml?query=branch%3Amaster+event%3Aschedule).

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,7 +1,8 @@
 name: Playwright Tests
 on:
-  push:
-    branches: [temp-actions]
+  # Schedule integration tests to see the real examples are not broken
+  schedule:
+    - cron: '0 2 * * *'
   pull_request:
     branches: [main, master]
   merge_group:
@@ -32,3 +33,11 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 30
+      - name: open issue
+        if: failure() && github.ref == 'refs/heads/master'
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          update_existing: false
+          filename: .github/ISSUE_TEMPLATE/playwright-nighly-failed.md

--- a/.github/workflows/real-integration.yml
+++ b/.github/workflows/real-integration.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js 18
         uses: actions/setup-node@v3
         with:
           node-version: 18.x

--- a/src/background/advisory/snyk.test.js
+++ b/src/background/advisory/snyk.test.js
@@ -24,7 +24,7 @@ describe('snyk', () => {
           },
           maintenance: {
             level: expect.stringMatching(/^GOOD|WARNING|BAD$/),
-            description: 'Sustainable',
+            description: 'Inactive',
           },
           community: {
             level: expect.stringMatching(/^GOOD|WARNING|BAD$/),


### PR DESCRIPTION
This pull request adds a new job to the Playwright Tests workflow that runs e2e nightly tests. If the tests fail, it opens an issue using the "Playwright Nightly failed" issue template. This helps to identify and address any failures in the nightly tests.