### PR TITLE
fix: yarn argument value identified as a package

### DIFF
--- a/src/content/registry/npm.js
+++ b/src/content/registry/npm.js
@@ -20,12 +20,24 @@ const parsePackageString = (str) => {
   };
 };
 
-const parseNpmCommand = createParseCommand(
-  'npm',
-  (line) => line.match(npmInstall),
-  (word) => word.length + 1,
-  parsePackageString
-);
+const npmOptionWithArgToIgnore = ['--network-timeout', '--network-concurrency'];
+
+//npm
+const handleArgument = (argument, restCommandWords) => {
+  let index = 0;
+  index += argument.length + 1; // +1 for the space removed by split
+
+  if (!npmOptionWithArgToIgnore.includes(argument)) {
+    return index;
+  }
+
+  if (argument.includes('=')) return index;
+
+  index += restCommandWords.shift().length + 1;
+  return index;
+};
+
+const parseNpmCommand = createParseCommand('npm', (line) => line.match(npmInstall), handleArgument, parsePackageString);
 
 // npx
 const parseOnlyFirstPackage = (str, argsAndPackagesWords) => {

--- a/src/content/registry/npm.test.js
+++ b/src/content/registry/npm.test.js
@@ -20,6 +20,7 @@ describe('npm', () => {
       'npm install -g',
       '`npm install node-sass`', // this is not a valid command because of the `
       'npm create-react-app my-app',
+      'yarn add <yourPackage> --network-timeout 100000',
     ])('should return empty array if no packages found', (command) => {
       expect(parseCommand(command)).toStrictEqual([]);
     });

--- a/src/content/registry/shared.js
+++ b/src/content/registry/shared.js
@@ -6,6 +6,10 @@ const finishAllWords = (argsAndPackagesWords) => {
   return length;
 };
 
+const isNumber = (str) => {
+  return /^\d+(\.\d+)?$/.test(str);
+};
+
 /**
  * @param {string} registryName `type` in result element
  * @param {(line: string) => RegExpMatchArray} getBaseCommandMatch get the base command match for a line (examples: `pip install`, `yarn add`)
@@ -41,7 +45,7 @@ export const createParseCommand =
           continue;
         }
 
-        if (word.startsWith('-')) {
+        if (word.startsWith('-') || isNumber(word)) {
           counterIndex += handleArgument(word, argsAndPackagesWords);
           continue;
         }

--- a/src/content/registry/shared.js
+++ b/src/content/registry/shared.js
@@ -6,10 +6,6 @@ const finishAllWords = (argsAndPackagesWords) => {
   return length;
 };
 
-const isNumber = (str) => {
-  return /^\d+(\.\d+)?$/.test(str);
-};
-
 /**
  * @param {string} registryName `type` in result element
  * @param {(line: string) => RegExpMatchArray} getBaseCommandMatch get the base command match for a line (examples: `pip install`, `yarn add`)
@@ -45,7 +41,7 @@ export const createParseCommand =
           continue;
         }
 
-        if (word.startsWith('-') || isNumber(word)) {
+        if (word.startsWith('-')) {
           counterIndex += handleArgument(word, argsAndPackagesWords);
           continue;
         }

--- a/tests/real-examples/real-examples-results.yaml
+++ b/tests/real-examples/real-examples-results.yaml
@@ -424,6 +424,16 @@ https://stackoverflow.com/questions/3608384:
         </code>
       type: npm
       name: jade
+https://stackoverflow.com/questions/51508364:
+  comment: ignore 'yarn add <yourPackage> --network-timeout 100000'
+  post: answer
+  registry: npm
+  results:
+    - range: |-
+        <code>npx create-react-app app --use-npm
+        </code>
+      type: npm
+      name: create-react-app
 https://stackoverflow.com/questions/12008719:
   comment: npm install --save
   post: answer

--- a/tests/real-examples/real-examples.yaml
+++ b/tests/real-examples/real-examples.yaml
@@ -27,6 +27,10 @@ links:
     comment: ignore 'npm install -d' & find '/usr/local/bin/npm install jade'
     post: answer
     registry: npm
+  https://stackoverflow.com/questions/51508364:
+    comment: ignore 'yarn add <yourPackage> --network-timeout 100000'
+    post: answer
+    registry: npm
   https://stackoverflow.com/questions/12008719:
     comment: npm install --save
     post: answer


### PR DESCRIPTION
Fixes #156

In case of Number, handle it as Argument and skip this word.
After the fix:
![Screen Shot 2024-02-18 at 21 42 13](https://github.com/os-scar/overlay/assets/6542413/02c26ac7-62d4-4ba0-886b-3a3b1ec0df6b)
